### PR TITLE
handle no extent in query

### DIFF
--- a/src/SortTileRecursiveTree.jl
+++ b/src/SortTileRecursiveTree.jl
@@ -134,8 +134,11 @@ function query(tree::STRtree, extent::Extent)
     query!(query_result, tree.rootnode, extent)
     return unique(sort!(query_result))
 end
-
-query(tree::STRtree, geom) = query(tree, GI.extent(geom))
+function query(tree::STRtree, geom) 
+    ext = GI.extent(geom)
+    isnothing(ext) && throw(ArgumentError("No Extent found in object $geom"))
+    return query(tree, ext)
+end
 
 """recursively query the nodes until a leaf node is reached"""
 function query!(query_result::Vector{Int}, node::STRNode, extent::Extent)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ import GeoInterface as GI
 
         @test query(tree, Extent(X=(0, 1.5), Y=(0, 1.5))) == [1]
         @test query(tree, Extent(X=(0, 0.5), Y=(0, 0.5))) == []
+        @test_throws ArgumentError query(tree, 1)
     end
     
     @testset "Many points" begin


### PR DESCRIPTION
This PR prevents stack overflow when the queried object has no extent, and instead throws an `ArgumentError`